### PR TITLE
fix(): block rewards

### DIFF
--- a/src/block/block.controller.ts
+++ b/src/block/block.controller.ts
@@ -29,6 +29,12 @@ export class BlockController {
   @Post("transaction")
   @HttpCode(200)
   public async getTransaction(@Body() body: BlockTransactionRequest) {
+    const validationResult = await BlockTransactionRequest.validate(body);
+
+    if (validationResult) {
+      throw new HttpException(validationResult, 500);
+    }
+
     return this.blockService.getBlockTransaction(
       body.block_identifier.index,
       body.transaction_identifier.hash

--- a/src/block/reward.service.ts
+++ b/src/block/reward.service.ts
@@ -6,6 +6,7 @@ import { getRPCProvider } from "../utils/client";
 @Injectable()
 export class RewardService {
   private communityFundReward = BigNumber.from("600900558100000000");
+  private communityFundAddress = "0x1204700000000000000000000000000000000003";
   private communityFundAddressStorageLocation = 11;
 
   private rewardContractABI = [
@@ -23,13 +24,13 @@ export class RewardService {
       provider
     );
 
-    const communityFundAddress = ethers.utils.hexStripZeros(
-      await provider.getStorageAt(
-        rewardContract.address,
-        this.communityFundAddressStorageLocation,
-        blockNumber
-      )
-    );
+    // const communityFundAddress = ethers.utils.hexStripZeros(
+    //   await provider.getStorageAt(
+    //     rewardContract.address,
+    //     this.communityFundAddressStorageLocation,
+    //     blockNumber
+    //   )
+    // );
 
     const payoutAddress = await rewardContract.payoutAddresses(miner);
 
@@ -42,7 +43,7 @@ export class RewardService {
 
     return [
       { address: rewardAddress, value: minerReward },
-      { address: communityFundAddress, value: this.communityFundReward },
+      { address: this.communityFundAddress, value: this.communityFundReward },
     ];
   }
 }

--- a/src/models/BlockIdentifier.ts
+++ b/src/models/BlockIdentifier.ts
@@ -1,4 +1,23 @@
+import { Errors } from "./Errors";
+import { getRPCProvider } from "../utils/client";
+
 export class BlockIdentifier {
-  constructor(public index: number, public hash: string) {
+  constructor(public index: number, public hash: string) {}
+
+  static async validate(blockIdentifier: BlockIdentifier) {
+    if (!blockIdentifier?.hash || !blockIdentifier?.index) {
+      return Errors.BLOCK_REQUIRED;
+    }
+
+    const provider = getRPCProvider();
+    const block = await provider.getBlock(blockIdentifier.index);
+
+    if (!block) {
+      return Errors.BLOCK_NOT_FOUND;
+    }
+
+    if (block.hash !== blockIdentifier.hash) {
+      return Errors.BLOCK_HASH_MISMATCH;
+    }
   }
 }

--- a/src/models/BlockTransactionRequest.ts
+++ b/src/models/BlockTransactionRequest.ts
@@ -1,11 +1,30 @@
 import { TransactionIdentifier } from "./TransactionIdentifer";
 import { NetworkIdentifier } from "./NetworkIdentifier";
 import { PartialBlockIdentifier } from "./PartialBlockIdentifier";
+import { BlockIdentifier } from "./BlockIdentifier";
 
 export class BlockTransactionRequest {
   constructor(
     public network_identifier: NetworkIdentifier,
-    public block_identifier: PartialBlockIdentifier,
+    public block_identifier: BlockIdentifier,
     public transaction_identifier: TransactionIdentifier
   ) {}
+
+  static async validate(request: BlockTransactionRequest) {
+    const networkValidationResult = NetworkIdentifier.validate(
+      request.network_identifier
+    );
+    const blockValidationResult = await BlockIdentifier.validate(
+      request.block_identifier
+    );
+    const transactionValidationResult = await TransactionIdentifier.validate(
+      request.transaction_identifier
+    );
+
+    return (
+      networkValidationResult ||
+      blockValidationResult ||
+      transactionValidationResult
+    );
+  }
 }

--- a/src/models/PartialBlockIdentifier.ts
+++ b/src/models/PartialBlockIdentifier.ts
@@ -1,21 +1,22 @@
 import { getRPCProvider } from "src/utils/client";
 import { Errors } from "./Errors";
+import { BlockIdentifier } from "./BlockIdentifier";
 
 export class PartialBlockIdentifier {
   constructor(public index?: number, public hash?: string) {}
 
   static async validate(blockIdentifier: PartialBlockIdentifier) {
     if (blockIdentifier?.hash && blockIdentifier?.index) {
-      const provider = getRPCProvider();
-      const block = await provider.getBlock(blockIdentifier.index);
+      return BlockIdentifier.validate(blockIdentifier as BlockIdentifier);
+    }
 
-      if (!block) {        
-        return Errors.BLOCK_NOT_FOUND;  
-      }
+    const blockId = blockIdentifier?.hash || blockIdentifier?.index;
 
-      if (block.hash !== blockIdentifier.hash) {
-        return Errors.BLOCK_HASH_MISMATCH;
-      }
+    const provider = getRPCProvider();
+    const block = await provider.getBlock(blockId);
+
+    if (!block) {
+      return Errors.BLOCK_NOT_FOUND;
     }
 
     return null;

--- a/src/models/TransactionIdentifer.ts
+++ b/src/models/TransactionIdentifer.ts
@@ -4,15 +4,17 @@ import { Errors } from "./Errors";
 export class TransactionIdentifier {
   constructor(public hash: string) {}
 
-  static async validate(transactionIdentifier: TransactionIdentifier) {    
+  static async validate(transactionIdentifier: TransactionIdentifier) {
     if (transactionIdentifier?.hash) {
       const provider = getRPCProvider();
-      const transaction = await provider.getTransaction(transactionIdentifier.hash);
+      const transaction = await provider.getTransaction(
+        transactionIdentifier.hash
+      );
+      const block = await provider.getBlock(transactionIdentifier.hash);
 
-      if (!transaction) {
-        return Errors.TX_NOT_FOUND;  
+      if (!transaction && !block) {
+        return Errors.TX_NOT_FOUND;
       }
-      
     }
 
     return null;


### PR DESCRIPTION
This PR fixes #16 by using block hash as transaction identification as recommended https://community.rosetta-api.org/t/block-rewards-without-transaction-hash/188/2