### PR TITLE
fix: implement missing cases that leads to reconciliation tests failing

### DIFF
--- a/mainnet.json
+++ b/mainnet.json
@@ -7,12 +7,13 @@
   "http_timeout": 300,
   "tip_delay": 60,
   "data": {
+    "start_index": 14618462,
     "historical_balance_enabled": true,
-    "reconciliation_disabled": true,
-    "inactive_discrepency_search_disabled": true,
+    "reconciliation_disabled": false,
+    "inactive_discrepency_search_disabled": false,
     "balance_tracking_disabled": false,
     "end_conditions": {
-      "tip": true
+      "index": 14619462
     }
   },
   "construction": {

--- a/results.md
+++ b/results.md
@@ -1,4 +1,4 @@
-#Test results
+# Test results
 
 ## Mainnet
 
@@ -43,56 +43,55 @@ rosetta-cli check:data --configuration-file mainnet.json
 ```
 
 ```
-Success: Tip End Condition [Tip: 14185770]
++--------------------+--------------------------------+--------+
+|  CHECK:DATA TESTS  |          DESCRIPTION           | STATUS |
++--------------------+--------------------------------+--------+
+| Request/Response   | Rosetta implementation         | PASSED |
+|                    | serviced all requests          |        |
++--------------------+--------------------------------+--------+
+| Response Assertion | All responses are correctly    | PASSED |
+|                    | formatted                      |        |
++--------------------+--------------------------------+--------+
+| Block Syncing      | Blocks are connected into a    | PASSED |
+|                    | single canonical chain         |        |
++--------------------+--------------------------------+--------+
+| Balance Tracking   | Account balances did not go    | PASSED |
+|                    | negative                       |        |
++--------------------+--------------------------------+--------+
+| Reconciliation     | No balance discrepencies were  | PASSED |
+|                    | found between computed and     |        |
+|                    | live balances                  |        |
++--------------------+--------------------------------+--------+
 
-+--------------------+--------------------------------+------------+
-|  CHECK:DATA TESTS  |          DESCRIPTION           |   STATUS   |
-+--------------------+--------------------------------+------------+
-| Request/Response   | Rosetta implementation         | PASSED     |
-|                    | serviced all requests          |            |
-+--------------------+--------------------------------+------------+
-| Response Assertion | All responses are correctly    | PASSED     |
-|                    | formatted                      |            |
-+--------------------+--------------------------------+------------+
-| Block Syncing      | Blocks are connected into a    | PASSED     |
-|                    | single canonical chain         |            |
-+--------------------+--------------------------------+------------+
-| Balance Tracking   | Account balances did not go    | PASSED     |
-|                    | negative                       |            |
-+--------------------+--------------------------------+------------+
-| Reconciliation     | No balance discrepencies were  | NOT TESTED |
-|                    | found between computed and     |            |
-|                    | live balances                  |            |
-+--------------------+--------------------------------+------------+
++--------------------------+--------------------------------+------------+
+|     CHECK:DATA STATS     |          DESCRIPTION           |   VALUE    |
++--------------------------+--------------------------------+------------+
+| Blocks                   | # of blocks synced             |       1001 |
++--------------------------+--------------------------------+------------+
+| Orphans                  | # of blocks orphaned           |          0 |
++--------------------------+--------------------------------+------------+
+| Transactions             | # of transaction processed     |       5099 |
++--------------------------+--------------------------------+------------+
+| Operations               | # of operations processed      |      12294 |
++--------------------------+--------------------------------+------------+
+| Accounts                 | # of accounts seen             |        966 |
++--------------------------+--------------------------------+------------+
+| Active Reconciliations   | # of reconciliations performed |       6236 |
+|                          | after seeing an account in a   |            |
+|                          | block                          |            |
++--------------------------+--------------------------------+------------+
+| Inactive Reconciliations | # of reconciliations performed |        489 |
+|                          | on randomly selected accounts  |            |
++--------------------------+--------------------------------+------------+
+| Exempt Reconciliations   | # of reconciliation failures   |          0 |
+|                          | considered exempt              |            |
++--------------------------+--------------------------------+------------+
+| Failed Reconciliations   | # of reconciliation failures   |          0 |
++--------------------------+--------------------------------+------------+
+| Skipped Reconciliations  | # of reconciliations skipped   |          0 |
++--------------------------+--------------------------------+------------+
+| Reconciliation Coverage  | % of accounts that have been   | 57.867495% |
+|                          | reconciled                     |            |
++--------------------------+--------------------------------+------------+
 
-+--------------------------+--------------------------------+-----------+
-|     CHECK:DATA STATS     |          DESCRIPTION           |   VALUE   |
-+--------------------------+--------------------------------+-----------+
-| Blocks                   | # of blocks synced             |        71 |
-+--------------------------+--------------------------------+-----------+
-| Orphans                  | # of blocks orphaned           |         0 |
-+--------------------------+--------------------------------+-----------+
-| Transactions             | # of transaction processed     |       369 |
-+--------------------------+--------------------------------+-----------+
-| Operations               | # of operations processed      |      1476 |
-+--------------------------+--------------------------------+-----------+
-| Accounts                 | # of accounts seen             |       142 |
-+--------------------------+--------------------------------+-----------+
-| Active Reconciliations   | # of reconciliations performed |         0 |
-|                          | after seeing an account in a   |           |
-|                          | block                          |           |
-+--------------------------+--------------------------------+-----------+
-| Inactive Reconciliations | # of reconciliations performed |         0 |
-|                          | on randomly selected accounts  |           |
-+--------------------------+--------------------------------+-----------+
-| Exempt Reconciliations   | # of reconciliation failures   |         0 |
-|                          | considered exempt              |           |
-+--------------------------+--------------------------------+-----------+
-| Failed Reconciliations   | # of reconciliation failures   |         0 |
-+--------------------------+--------------------------------+-----------+
-| Skipped Reconciliations  | # of reconciliations skipped   |         0 |
-+--------------------------+--------------------------------+-----------+
-| Reconciliation Coverage  | % of accounts that have been   | 0.000000% |
-|                          | reconciled                     |           |
-+--------------------------+--------------------------------+-----------+
 ```


### PR DESCRIPTION
This PR implements missing cases required to pass reconciliation tests, this includes smart contracts internal transactions, suicide calls and contract creation.

Additionally the test config for main net was modified such as it uses 1000 blocks (from 14618462 to 14619462), this yields approximately 1000 accounts with 6000 reconciliation actions.